### PR TITLE
Incorrect API reference

### DIFF
--- a/GiphyApiWrapper/Giphy.cs
+++ b/GiphyApiWrapper/Giphy.cs
@@ -208,7 +208,7 @@ namespace GiphyApiWrapper
 
             /* Finish exception checks */
 
-            string url = $@"{ _getGifByIdUrl }/gif_id={ gifId }?api_key={ _apiKey }";
+            string url = $@"{ _getGifByIdUrl }/gifs/{ gifId }?api_key={ _apiKey }";
 
             var response = await _httpHandler.GetAsync(url);
 


### PR DESCRIPTION
Issue related to https://github.com/KeeganFargher/GiphyApiWrapper/issues/2

Corrected to the following 

`string url = $@"{ _getGifByIdUrl }/gifs/{ gifId }?api_key={ _apiKey }";`